### PR TITLE
Fix nullable fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "configurations": [
+      {
+        "name": "Debug Jest Tests",
+        "type": "node",
+        "request": "launch",
+        "protocol":"auto",
+        "runtimeArgs": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/.bin/jest",
+          "--runInBand"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "skipFiles": [
+          "<node_internals>/**",
+          "node_modules/**/*.js"
+        ],
+        "port": 9229
+      }
+    ]
+  }

--- a/src/__tests__/Client2.test.ts
+++ b/src/__tests__/Client2.test.ts
@@ -1,0 +1,67 @@
+import {
+    client,
+    Field,
+    Query,
+} from '../../src';
+
+/**
+ *
+query {
+  allStarships {
+    starships {
+      name
+      pilotConnection {
+        pilots {
+          name
+          species {
+            name
+          }
+        }
+      }
+    }
+  }
+}
+ */
+
+
+const allStarshipsQuery = new Query('allStarships')
+    .addField(
+        new Field('starships', true)
+            .addFieldList(['name'])
+            .addField(
+                new Field('pilotConnection')
+                .addField(
+                    new Field('pilots', true)
+                        .addFieldList(['name'])
+                        .addField(
+                            new Field('species')
+                                .addFieldList(['name'])
+                        )
+                )
+            )
+    );
+
+// https://graphql.org/swapi-graphql/
+client.setEndpoint('https://swapi-graphql.netlify.app/.netlify/functions/index')
+
+describe('data is fetched correctly from sw api', () => {
+    it('should be able to fetch query with nullable fields', async () => {
+        const result = await client.post(allStarshipsQuery);
+        expect(result).toBeDefined();
+
+        for (const starship of result.allStarships.starships) {
+            expect(starship).toHaveProperty('name');
+            expect(starship.pilotConnection.pilots).toBeInstanceOf(Array)
+
+            starship.pilotConnection.pilots.forEach(pilot => {
+                expect(pilot).toHaveProperty('name')
+                expect(typeof pilot.species === 'object').toBeTruthy()
+                if (pilot.species === null) {
+                    expect(pilot.species).toBeNull()
+                } else {
+                    expect(pilot.species).toHaveProperty('name')
+                }
+            })
+        }
+    });
+})

--- a/src/builder/AbstractField.ts
+++ b/src/builder/AbstractField.ts
@@ -52,7 +52,7 @@ export abstract class AbstractField<
     transformer?: (result: FieldReturnType) => any;
 
     constructor(
-        name: Name, 
+        name: Name,
         isArray?: ArrayExpected
     ) {
         this.name = name;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -100,13 +100,16 @@ export class Client {
             for (const child of field.children) {
                 if (child.tag === 'InlineFragment') {
                     for (const fragmentChild of child.children) {
-                        if (!Object.hasOwnProperty.call(result, fragmentChild.name)) {
+                        if (result === null || !Object.hasOwnProperty.call(result, fragmentChild.name)) {
                             continue;
                         }
 
                         await this.process(fragmentChild, result[fragmentChild.name], result);
                     }
                 } else {
+                    if (result === null || !Object.hasOwnProperty.call(result, child.name)) {
+                        continue;
+                    }
                     await this.process(child, result[child.name], result);
                 }
             }


### PR DESCRIPTION
This PR fixes Opus dying when a field is null but in query, it is defined as an object.
\+ debugger for tests (press F5 in VSCode)
\+ test with SWAPI query which has field `species` which is null on some results.